### PR TITLE
Fixed wrong output path for yarn watch

### DIFF
--- a/DNN Platform/Modules/ResourceManager/.gitignore
+++ b/DNN Platform/Modules/ResourceManager/.gitignore
@@ -1,2 +1,1 @@
-Scripts/dnn-resource-manager
-Scripts/types
+/Scripts

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/package.json
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build": "stencil build --docs",
-    "watch": "stencil build --dev --watch",
+    "watch": "stencil build --config stencil.dnn.config.ts --dev --watch",
     "start": "stencil build --dev --watch --serve",
     "generate": "stencil generate"
   },

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components.d.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components.d.ts
@@ -138,38 +138,6 @@ export namespace Components {
         "items": Item[];
     }
 }
-export interface DnnRmCreateFolderCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLDnnRmCreateFolderElement;
-}
-export interface DnnRmDeleteItemsCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLDnnRmDeleteItemsElement;
-}
-export interface DnnRmEditFileCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLDnnRmEditFileElement;
-}
-export interface DnnRmEditFolderCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLDnnRmEditFolderElement;
-}
-export interface DnnRmFolderListCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLDnnRmFolderListElement;
-}
-export interface DnnRmFolderListItemCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLDnnRmFolderListItemElement;
-}
-export interface DnnRmMoveItemsCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLDnnRmMoveItemsElement;
-}
-export interface DnnRmUnlinkItemsCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLDnnRmUnlinkItemsElement;
-}
 declare global {
     interface HTMLDnnActionCopyUrlElement extends Components.DnnActionCopyUrl, HTMLStencilElement {
     }
@@ -397,7 +365,7 @@ declare namespace LocalJSX {
         /**
           * Fires when there is a possibility that some folders have changed. Can be used to force parts of the UI to refresh.
          */
-        "onDnnRmFoldersChanged"?: (event: DnnRmCreateFolderCustomEvent<void>) => void;
+        "onDnnRmFoldersChanged"?: (event: CustomEvent<void>) => void;
     }
     interface DnnRmDeleteItems {
         /**
@@ -407,7 +375,7 @@ declare namespace LocalJSX {
         /**
           * Fires when there is a possibility that some folders have changed. Can be used to force parts of the UI to refresh.
          */
-        "onDnnRmFoldersChanged"?: (event: DnnRmDeleteItemsCustomEvent<void>) => void;
+        "onDnnRmFoldersChanged"?: (event: CustomEvent<void>) => void;
     }
     interface DnnRmEditFile {
         /**
@@ -417,7 +385,7 @@ declare namespace LocalJSX {
         /**
           * Fires when there is a possibility that some folders have changed. Can be used to force parts of the UI to refresh.
          */
-        "onDnnRmFoldersChanged"?: (event: DnnRmEditFileCustomEvent<void>) => void;
+        "onDnnRmFoldersChanged"?: (event: CustomEvent<void>) => void;
     }
     interface DnnRmEditFolder {
         /**
@@ -427,7 +395,7 @@ declare namespace LocalJSX {
         /**
           * Fires when there is a possibility that some folders have changed. Can be used to force parts of the UI to refresh.
          */
-        "onDnnRmFoldersChanged"?: (event: DnnRmEditFolderCustomEvent<void>) => void;
+        "onDnnRmFoldersChanged"?: (event: CustomEvent<void>) => void;
     }
     interface DnnRmFileContextMenu {
         /**
@@ -451,7 +419,7 @@ declare namespace LocalJSX {
         /**
           * Fires when a folder is picked.
          */
-        "onDnnRmFolderListFolderPicked"?: (event: DnnRmFolderListCustomEvent<FolderTreeItem>) => void;
+        "onDnnRmFolderListFolderPicked"?: (event: CustomEvent<FolderTreeItem>) => void;
     }
     interface DnnRmFolderListItem {
         /**
@@ -465,11 +433,11 @@ declare namespace LocalJSX {
         /**
           * Fires when a folder is clicked.
          */
-        "onDnnRmFolderListItemClicked"?: (event: DnnRmFolderListItemCustomEvent<FolderTreeItem>) => void;
+        "onDnnRmFolderListItemClicked"?: (event: CustomEvent<FolderTreeItem>) => void;
         /**
           * Fires when a context menu is opened for this item. Emits the folder ID.
          */
-        "onDnnRmcontextMenuOpened"?: (event: DnnRmFolderListItemCustomEvent<number>) => void;
+        "onDnnRmcontextMenuOpened"?: (event: CustomEvent<number>) => void;
         /**
           * The ID of the parent folder.
          */
@@ -501,7 +469,7 @@ declare namespace LocalJSX {
         /**
           * Fires when there is a possibility that some folders have changed. Can be used to force parts of the UI to refresh.
          */
-        "onDnnRmFoldersChanged"?: (event: DnnRmMoveItemsCustomEvent<void>) => void;
+        "onDnnRmFoldersChanged"?: (event: CustomEvent<void>) => void;
     }
     interface DnnRmProgressBar {
         /**
@@ -527,7 +495,7 @@ declare namespace LocalJSX {
         /**
           * Fires when there is a possibility that some folders have changed. Can be used to force parts of the UI to refresh.
          */
-        "onDnnRmFoldersChanged"?: (event: DnnRmUnlinkItemsCustomEvent<void>) => void;
+        "onDnnRmFoldersChanged"?: (event: CustomEvent<void>) => void;
     }
     interface IntrinsicElements {
         "dnn-action-copy-url": DnnActionCopyUrl;

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/stencil.config.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/stencil.config.ts
@@ -10,12 +10,6 @@ export const config: Config = {
       esmLoaderPath: '../loader',
     },
     {
-      // For DNN yarn watch --scope dnn-resource-manager
-      type: 'dist',
-      esmLoaderPath: '../loader',
-      dir: dnnConfig?.WebsitePath ? dnnConfig.WebsitePath : '../Scripts',
-    },
-    {
       type: 'dist-custom-elements',
     },
     {

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/stencil.dnn.config.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/stencil.dnn.config.ts
@@ -1,0 +1,15 @@
+import { config as originalConfig } from './stencil.config';
+import dnnConfig from '../../../../settings.local.json';
+
+export const config = {
+  ...originalConfig,
+  ouputTargets: [
+    ...originalConfig.outputTargets,
+    {
+      // For DNN yarn watch --scope dnn-resource-manager
+      type: 'dist',
+      esmLoaderPath: '../loader',
+      dir: dnnConfig?.WebsitePath ? `${dnnConfig.WebsitePath}\\DesktopModules\\ResourceManager\\Scripts` : '../Scripts',
+    }
+  ]
+}


### PR DESCRIPTION
Also creates a specific file for the dnn watch, if not we would required to decrale the output folder in the package.json which does not smell good.