### PR TITLE
Folder context menu dismiss

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/actions/dnn-action-upload-file/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/actions/dnn-action-upload-file/readme.md
@@ -12,6 +12,13 @@
 | `parentFolderId` | `parent-folder-id` |             | `number` | `undefined` |
 
 
+## Events
+
+| Event                 | Description                                                                                                        | Type                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `dnnRmFoldersChanged` | Fires when there is a possibility that some folders have changed. Can be used to force parts of the UI to refresh. | `CustomEvent<void>` |
+
+
 ## Dependencies
 
 ### Used by

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list-item/dnn-rm-folder-list-item.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list-item/dnn-rm-folder-list-item.tsx
@@ -104,7 +104,7 @@ export class DnnRmFolderListItem {
   }
 
   private dismissContextMenu() {
-    const existingMenus = this.el.shadowRoot.querySelectorAll(".contextMenu");
+    const existingMenus = this.el.shadowRoot.querySelectorAll("dnn-collapsible");
     existingMenus?.forEach(contextMenu => this.el.shadowRoot.removeChild(contextMenu));
   }
 


### PR DESCRIPTION
## Summary
This PR resolves a bug where the context menu within the folder list was not dismissed properly upon clicking off it.  

This also includes a README that had not been committed for a previous PR.