### PR TITLE
Added type/size verification before upload

### DIFF
--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -269,9 +269,6 @@
   <ItemGroup>
     <Folder Include="Scripts\" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="App_LocalResources\Files.resx" />
-  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components.d.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components.d.ts
@@ -144,6 +144,10 @@ export namespace Components {
          */
         "filter": string;
         /**
+          * The maximal allowed file upload size
+         */
+        "maxUploadFileSize": number;
+        /**
           * The validation code to use for uploads.
          */
         "validationCode": string;
@@ -596,6 +600,10 @@ declare namespace LocalJSX {
           * Optionally limit the file types that can be uploaded.
          */
         "filter": string;
+        /**
+          * The maximal allowed file upload size
+         */
+        "maxUploadFileSize": number;
         /**
           * The validation code to use for uploads.
          */

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-queued-file/dnn-rm-queued-file.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-queued-file/dnn-rm-queued-file.tsx
@@ -23,6 +23,9 @@ export class DnnRmQueuedFile {
     /** Optionally limit the file types that can be uploaded. */
     @Prop() filter!: string;
 
+    /** The maximal allowed file upload size */
+    @Prop() maxUploadFileSize!: number;
+
     @State() overwrite = false;
     @State() fileUploadResults: UploadFromLocalResponse;
     @State() progress: number;
@@ -73,6 +76,35 @@ export class DnnRmQueuedFile {
 
     private uploadFile(){
         return new Promise<string>((resolve, reject) => {
+            const extension = this.file.name.split('.').pop();
+            if (this.filter.split(',').indexOf(extension) === -1) {
+                const message = `'.${extension}' ${state.localization.InvalidExtensionMessage}`;
+                this.fileUploadResults = {
+                    alreadyExists: false,
+                    message: message,
+                    fileIconUrl: undefined,
+                    fileName: this.file.name,
+                    fileId: -1,
+                    orientation: 0,
+                };
+                reject(message);
+                return;
+            }
+
+            if (this.file.size > this.maxUploadFileSize) {
+                const message = `${this.file.name} ${state.localization.FileSizeErrorMessage} ${getFileSize(this.maxUploadFileSize)}`; 
+                this.fileUploadResults = {
+                    alreadyExists: false,
+                    message: message,
+                    fileIconUrl: undefined,
+                    fileName: this.file.name,
+                    fileId: -1,
+                    orientation: 0,
+                };
+                reject(message);
+                return;
+            }
+            
             const headers = this.servicesFramework.getModuleHeaders();
     
             const formData = new FormData();

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-queued-file/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-queued-file/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property                      | Attribute         | Description                                           | Type      | Default     |
-| ----------------------------- | ----------------- | ----------------------------------------------------- | --------- | ----------- |
-| `extract`                     | `extract`         | Whether to extract uploaded zip files.                | `boolean` | `false`     |
-| `file` _(required)_           | --                | The file to upload.                                   | `File`    | `undefined` |
-| `filter` _(required)_         | `filter`          | Optionally limit the file types that can be uploaded. | `string`  | `undefined` |
-| `validationCode` _(required)_ | `validation-code` | The validation code to use for uploads.               | `string`  | `undefined` |
+| Property                         | Attribute              | Description                                           | Type      | Default     |
+| -------------------------------- | ---------------------- | ----------------------------------------------------- | --------- | ----------- |
+| `extract`                        | `extract`              | Whether to extract uploaded zip files.                | `boolean` | `false`     |
+| `file` _(required)_              | --                     | The file to upload.                                   | `File`    | `undefined` |
+| `filter` _(required)_            | `filter`               | Optionally limit the file types that can be uploaded. | `string`  | `undefined` |
+| `maxUploadFileSize` _(required)_ | `max-upload-file-size` | The maximal allowed file upload size                  | `number`  | `undefined` |
+| `validationCode` _(required)_    | `validation-code`      | The validation code to use for uploads.               | `string`  | `undefined` |
 
 
 ## Dependencies

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-upload-file/dnn-rm-upload-file.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-upload-file/dnn-rm-upload-file.tsx
@@ -26,6 +26,7 @@ export class DnnRmUploadFile {
   private itemsClient: ItemsClient;
   private allowedExtensions: string;
   private validationCode: string;
+  private maxUploadFileSize: number;
   private extract = false;
 
   constructor() {
@@ -37,6 +38,7 @@ export class DnnRmUploadFile {
       .then(data => {
         this.allowedExtensions = data.allowedExtensions;
         this.validationCode = data.validationCode;
+        this.maxUploadFileSize = data.maxUploadFileSize;
       })
       .catch(err => alert(err));
   }
@@ -56,13 +58,16 @@ export class DnnRmUploadFile {
           {state.localization.ExtractUploads}
           </dnn-checkbox>
         </label>
-        <dnn-dropzone onFilesSelected={e => this.handleFilesDropped(e.detail)}></dnn-dropzone>
+        <dnn-dropzone
+          onFilesSelected={e => this.handleFilesDropped(e.detail)}
+        />
         {this.allowedExtensions && this.validationCode && this.queuedFiles.map(file => 
           <dnn-rm-queued-file
             file={file}
             validationCode={this.validationCode}
             filter={this.allowedExtensions}
             extract={this.extract}
+            maxUploadFileSize={this.maxUploadFileSize}
           />
         )}
       </Host>

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
@@ -518,6 +518,7 @@ export interface GetAllowedFileExtensionsResponse {
     /** A coma delimited list of the allowed file extensions. */
     allowedExtensions: string;
     validationCode: string;
+    maxUploadFileSize: number;
 }
 
 export interface FolderInfo{

--- a/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
@@ -653,7 +653,9 @@ namespace Dnn.Modules.ResourceManager.Services
 
             var validationCode = ValidationUtils.ComputeValidationCode(parameters);
 
-            return this.Ok(new { allowedExtensions, validationCode });
+            var maxUploadFileSize = Config.GetMaxUploadSize();
+
+            return this.Ok(new { allowedExtensions, validationCode, maxUploadFileSize });
         }
 
         private static string GetFileIconUrl(string extension)


### PR DESCRIPTION
Before this PR, the upload would happen before the file type and size validation would happen. This validates those in the front end first to save on an upload that would not succeed anyway.
